### PR TITLE
feat: copy AdiantiCoreApplication on install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,13 @@
     "sort-packages": true
   },
   "scripts": {
-    "test": "phpunit"
+    "test": "phpunit",
+    "post-install-cmd": [
+      "GOlib\\Log\\ComposerScripts::postInstall"
+    ],
+    "post-update-cmd": [
+      "GOlib\\Log\\ComposerScripts::postUpdate"
+    ]
   },
   "extra": {
     "branch-alias": {

--- a/src/AdiantiCoreApplication.php
+++ b/src/AdiantiCoreApplication.php
@@ -9,7 +9,7 @@ use ReflectionMethod;
 use Adianti\Control\TPage;
 use Adianti\Widget\Base\TScript;
 use Adianti\Widget\Dialog\TMessage;
-use GoLib\Logging\ErrorHandlerSetup;
+use GOlib\Log\Service\ErrorHandlerSetup;
 use Adianti\Core\AdiantiCoreTranslator;
 
 /**

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GOlib\Log;
+
+use Composer\Script\Event;
+
+/**
+ * Composer scripts for library installation lifecycle.
+ */
+class ComposerScripts
+{
+    /**
+     * Handle post-install Composer event.
+     */
+    public static function postInstall(Event $event): void
+    {
+        self::copyAdiantiCoreApplication($event);
+    }
+
+    /**
+     * Handle post-update Composer event.
+     */
+    public static function postUpdate(Event $event): void
+    {
+        self::copyAdiantiCoreApplication($event);
+    }
+
+    /**
+     * Copy AdiantiCoreApplication.php to project's Adianti core directory.
+     */
+    private static function copyAdiantiCoreApplication(Event $event): void
+    {
+        $source = __DIR__ . '/AdiantiCoreApplication.php';
+        $target = getcwd() . '/lib/adianti/core/AdiantiCoreApplication.php';
+
+        if (!is_file($source)) {
+            $event->getIO()->writeError("Source file not found: {$source}");
+            return;
+        }
+
+        $targetDir = dirname($target);
+        if (!is_dir($targetDir)) {
+            if (!mkdir($targetDir, 0777, true) && !is_dir($targetDir)) {
+                $event->getIO()->writeError("Unable to create directory: {$targetDir}");
+                return;
+            }
+        }
+
+        if (!copy($source, $target)) {
+            $event->getIO()->writeError("Failed to copy AdiantiCoreApplication.php to {$target}");
+            return;
+        }
+
+        $event->getIO()->write("AdiantiCoreApplication.php copied to lib/adianti/core");
+    }
+}

--- a/src/service/ErrorHandlerSetup.php
+++ b/src/service/ErrorHandlerSetup.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GOlib\Log\Service;
+
+use ErrorException;
+use Throwable;
+
+/**
+ * Configura os tratadores de erros e exceções da aplicação.
+ *
+ * @version    1.0.0
+ */
+class ErrorHandlerSetup
+{
+    /**
+     * Registra os tratadores globais de erros e exceções.
+     */
+    public static function register(): void
+    {
+        $handler = ErrorHandlerFactory::create();
+
+        set_exception_handler([$handler, 'handle']);
+
+        set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline) use ($handler): bool {
+            $handler->handle(new ErrorException($errstr, 0, $errno, $errfile, $errline));
+            return true;
+        });
+    }
+
+    /**
+     * Encaminha a exceção para o tratador configurado.
+     */
+    public static function handleException(Throwable $exception): void
+    {
+        $handler = ErrorHandlerFactory::create();
+        $handler->handle($exception);
+    }
+}


### PR DESCRIPTION
## Summary
- add composer scripts to copy AdiantiCoreApplication.php into project lib on install/update
- introduce ErrorHandlerSetup service and fix AdiantiCoreApplication's namespace to use it

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68aca94f4998832da89000c875f120fc