### PR TITLE
Validate config file presence and log directory permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ SSH (`git@github.com`) garantindo que sua chave pública esteja cadastrada no Gi
 
 ## Configuração
 
-1. Copie `src/logging.ini` para o diretório de configuração do seu projeto.
-2. Ajuste as opções conforme necessário. Exemplo:
+1. Copie `src/logging.ini` para `app/config/go-lib-logging.ini` no seu projeto.
+2. Certifique-se de que o diretório configurado em `file_handler.path` exista e possua permissão de escrita.
+3. Ajuste as opções conforme necessário. Exemplo:
 
 ```ini
 [logging]

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -18,18 +18,30 @@ class ConfigService
 
     private static function loadConfig(): void
     {
-        if (self::$config === null) {
-            $app_ini_path = 'app/config/application.ini';
-            $log_ini_path = 'app/config/go-lib-logging.ini';
-
-            $app_ini = file_exists($app_ini_path) ? parse_ini_file($app_ini_path, true) : [];
-            $log_ini = file_exists($log_ini_path) ? parse_ini_file($log_ini_path, true) : [];
-            
-            $app_ini = is_array($app_ini) ? $app_ini : [];
-            $log_ini = is_array($log_ini) ? $log_ini : [];
-            
-            self::$config = array_merge_recursive($app_ini, $log_ini);
+        if (self::$config !== null) {
+            return;
         }
+
+        $app_ini_path = 'app/config/application.ini';
+        $log_ini_path = 'app/config/go-lib-logging.ini';
+
+        $app_ini = [];
+        if (file_exists($app_ini_path)) {
+            $app_ini = parse_ini_file($app_ini_path, true) ?: [];
+        }
+
+        if (!is_file($log_ini_path) || !is_readable($log_ini_path)) {
+            error_log('[go-lib-logging] Arquivo de configuração ausente: ' . $log_ini_path);
+            throw new \RuntimeException('Arquivo de configuração não encontrado: ' . $log_ini_path);
+        }
+
+        $log_ini = parse_ini_file($log_ini_path, true);
+        if ($log_ini === false) {
+            error_log('[go-lib-logging] Falha ao ler configuração: ' . $log_ini_path);
+            throw new \RuntimeException('Falha ao ler configuração: ' . $log_ini_path);
+        }
+
+        self::$config = array_merge_recursive($app_ini, $log_ini);
     }
 
     /**

--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -112,6 +112,12 @@ class LogService
         $fileConfig = ConfigService::get('file_handler', null, []);
         $logPath = $fileConfig['path'] ?? 'app/logs/serket.log';
         $logDays = (int) ($fileConfig['days'] ?? 14);
+        $dir = dirname($logPath);
+        if (!is_dir($dir) || !is_writable($dir)) {
+            error_log('[go-lib-logging] Diretório de log inacessível: ' . $dir);
+            return;
+        }
+
         $fileHandler = new RotatingFileHandler($logPath, $logDays, Level::Debug);
         $fileHandler->setFormatter($formatter);
         $this->logger->pushHandler($fileHandler);

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use GOlib\Log\Service\ConfigService;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+
+final class ConfigServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $ref = new ReflectionClass(ConfigService::class);
+        $prop = $ref->getProperty('config');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
+    }
+
+    public function testThrowsWhenConfigFileMissing(): void
+    {
+        $this->expectException(RuntimeException::class);
+        ConfigService::get('logging');
+    }
+}


### PR DESCRIPTION
## Summary
- Throw RuntimeException if `go-lib-logging.ini` is missing or unreadable and log to PHP error log
- Warn and skip file handler when log directory lacks write access
- Document config file location and log directory permissions
- Add unit test for missing config detection

## Testing
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68acdaf92b28832d8711bb0554eab7a0